### PR TITLE
Enable cookie and device tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,13 @@ For more information about types of webhooks you can receive see http://help.thi
 ## API Documentation
 
 API Documentation is available at [http://help.thisdata.com/docs/apiv1events](http://help.thisdata.com/docs/apiv1events).
+
+## Test
+Run the unit tests
+```sh
+npm test
+```
+
+## Contributing
+Bug reports and pull requests are welcome on GitHub at https://github.com/thisdata/thisdata-node
+

--- a/lib/event.js
+++ b/lib/event.js
@@ -1,23 +1,49 @@
+var cookie = require('cookie');
+var cookieName;
+
 function remoteIpFromRequest(req){
   if(!req) return '';
-  return req.headers['X-FORWARDED-FOR'] || req.connection.remoteAddress;
+  return req.headers['x-forwarded-for'] || req.connection.remoteAddress;
 }
 
 function userAgentFromRequest(req){
   if(!req) return '';
-  return req.headers['User-Agent']
+  return req.headers['user-agent']
+}
+
+function cookieIdFromRequest(req){
+  if(!req) return null;
+
+  var cookies = cookie.parse(req.headers['cookie'] || '');
+
+  return cookies[cookieName] || null;
 }
 
 function buildEvent(req, options){
   var options = options || {};
+  var session = options.session || { };
 
   return {
     ip: options.ip || remoteIpFromRequest(req),
     user_agent: options.userAgent || userAgentFromRequest(req),
     user: options.user || {
       id: 'anonymous'
-    }
+    },
+    session: {
+      id: session.id || null,
+      td_cookie_id: cookieIdFromRequest(req),
+      td_cookie_expected: session.cookieExpected || false
+    },
+    device: options.device || {}
   }
 }
 
-exports.build = buildEvent;
+module.exports = function(options){
+
+  var options = options || {};
+  cookieName = options.cookieName || "__tdli";
+
+  return {
+    build: buildEvent
+  };
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ var crypto = require('crypto');
 var scmp = require('scmp');
 
 var verbs = require('./verbs');
-var event = require('./event');
+var Event = require('./event');
 
 function ThisData (apiKey, options) {
   if (!(this instanceof ThisData)) return new ThisData(apiKey, options);
@@ -13,14 +13,14 @@ function ThisData (apiKey, options) {
   var options = options || {};
   this.apiKey = apiKey;
   this.host = options.host || 'https://api.thisdata.com';
-
   this.verbs = verbs;
+  this.event = new Event(options);
 }
 
 ThisData.prototype.track = function(req, options, callback){
   var options = options || {};
 
-  var ev = event.build(req, options);
+  var ev = this.event.build(req, options);
   ev.verb = options.verb || verbs.LOG_IN;
 
   this.send('events', ev, callback);
@@ -29,7 +29,7 @@ ThisData.prototype.track = function(req, options, callback){
 ThisData.prototype.verify = function(req, options, callback){
   assert(typeof callback === 'function', 'You must pass a callback function to this method');
 
-  var ev = event.build(req, options);
+  var ev = this.event.build(req, options);
 
   this.send('verify', ev, callback);
 };

--- a/package.json
+++ b/package.json
@@ -28,12 +28,14 @@
   },
   "homepage": "https://github.com/thisdata/thisdata-node#readme",
   "dependencies": {
+    "cookie": "^0.3.1",
     "request": "^2.72.0",
     "scmp": "^1.0.0"
   },
   "devDependencies": {
-    "mocha": "2.5.2",
-    "express": "^4.13.4"
+    "body-parser": "^1.15.2",
+    "express": "^4.13.4",
+    "mocha": "2.5.2"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Adds support for extracting the tracking cookie that is dropped by the ThisData javascript tracking code. 

Also lets you pass in `device.id` and `user.authenticated` properties.
